### PR TITLE
Fix for Add support for Substituting a custom User model #40

### DIFF
--- a/demo/example/foo/models.py
+++ b/demo/example/foo/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.conf import settings
 
 # Create your models here.
 from django.utils.encoding import python_2_unicode_compatible
@@ -7,7 +8,7 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class Foo(models.Model):
-    user = models.ForeignKey('auth.User')
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
     name = models.CharField(max_length=100, default="A new foo")
 
     def __str__(self):

--- a/plans/admin.py
+++ b/plans/admin.py
@@ -11,8 +11,7 @@ from plans.models import Invoice
 
 class UserLinkMixin(object):
     def user_link(self, obj):
-        change_url = urlresolvers.reverse('admin:auth_user_change', args=(obj.user.id,))
-        return '<a href="%s">%s</a>' % (change_url, obj.user.username)
+        return '<a href="">%s</a>' % obj.user.username
 
     user_link.short_description = 'User'
     user_link.allow_tags = True

--- a/plans/listeners.py
+++ b/plans/listeners.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from plans.models import Order, Invoice, UserPlan, Plan
@@ -25,7 +25,7 @@ def send_invoice_by_email(sender, instance, created, **kwargs):
         instance.send_invoice_by_email()
 
 
-@receiver(post_save, sender=User)
+@receiver(post_save, sender=get_user_model())
 def set_default_user_plan(sender, instance, created, **kwargs):
     """
     Creates default plan for the new user but also extending an account for default grace period.

--- a/plans/models.py
+++ b/plans/models.py
@@ -51,7 +51,7 @@ class Plan(OrderedModel):
                                     help_text=_('Is still available for purchase'))
     visible = models.BooleanField(_('visible'), default=True, db_index=True, help_text=_('Is visible in current offer'))
     created = models.DateTimeField(_('created'), db_index=True)
-    customized = models.ForeignKey('auth.User', null=True, blank=True, verbose_name=_('customized'))
+    customized = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, verbose_name=_('customized'))
     quotas = models.ManyToManyField('Quota', through='PlanQuota', verbose_name=_('quotas'))
     url = models.CharField(max_length=200, blank=True, help_text=_(
         'Optional link to page with more information (for clickable pricing table headers)'))
@@ -88,7 +88,7 @@ class BillingInfo(models.Model):
     """
     Stores customer billing data needed to issue an invoice
     """
-    user = models.OneToOneField('auth.User', verbose_name=_('user'))
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, verbose_name=_('user'))
     tax_number = models.CharField(_('VAT ID'), max_length=200, blank=True, db_index=True)
     name = models.CharField(_('name'), max_length=200, db_index=True)
     street = models.CharField(_('street'), max_length=200)
@@ -138,7 +138,7 @@ class UserPlan(models.Model):
     """
     Currently selected plan for user account.
     """
-    user = models.OneToOneField('auth.User', verbose_name=_('user'))
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, verbose_name=_('user'))
     plan = models.ForeignKey('Plan', verbose_name=_('plan'))
     expire = models.DateField(_('expire'), default=None, blank=True, null=True, db_index=True)
     active = models.BooleanField(_('active'), default=True, db_index=True)
@@ -376,7 +376,7 @@ class Order(models.Model):
 
     ])
 
-    user = models.ForeignKey('auth.User', verbose_name=_('user'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'))
     flat_name = models.CharField(max_length=200, blank=True, null=True)
     plan = models.ForeignKey('Plan', verbose_name=_('plan'), related_name="plan_order")
     pricing = models.ForeignKey('Pricing', blank=True, null=True, verbose_name=_(
@@ -503,7 +503,7 @@ class Invoice(models.Model):
         MONTHLY = 2
         ANNUALLY = 3
 
-    user = models.ForeignKey('auth.User')
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
     order = models.ForeignKey('Order')
     number = models.IntegerField(db_index=True)
     full_number = models.CharField(max_length=200)

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -10,9 +10,12 @@ logger = logging.getLogger('plans.tasks')
 @periodic_task(run_every=crontab(hour=0, minute=5))
 def expire_account():
 
-    logger.info('Started')
+    logger.info('Started expire_account periodic task')
 
-    for user in User.objects.select_related('userplan').filter(userplan__active=True,         userplan__expire__lt=datetime.date.today()).exclude(userplan__expire=None):
+    _user_model = get_user_model()
+
+    for user in _user_model.objects.select_related('userplan').filter(userplan__active=True,
+                                                                      userplan__expire__lt=datetime.date.today()).exclude(userplan__expire=None):
         user.userplan.expire_account()
 
     notifications_days_before = getattr(settings, 'PLAN_EXPIRATION_REMIND', [])

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -3,7 +3,7 @@ import logging
 from celery.schedules import crontab
 from celery.task.base import periodic_task
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 logger = logging.getLogger('plans.tasks')
 
@@ -19,5 +19,5 @@ def expire_account():
 
     if notifications_days_before:
         days = map(lambda x: datetime.date.today() + datetime.timedelta(days=x), notifications_days_before)
-        for user in User.objects.select_related('userplan').filter(userplan__active=True, userplan__expire__in=days):
+        for user in get_user_model().objects.select_related('userplan').filter(userplan__active=True, userplan__expire__in=days):
             user.userplan.remind_expire_soon()

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.core import mail
 from django.db.models import Q
@@ -30,19 +30,19 @@ class PlansTestCase(TestCase):
         mail.outbox = []
 
     def test_get_user_quota(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         self.assertEqual(get_user_quota(u),
                          {u'CUSTOM_WATERMARK': 1, u'MAX_GALLERIES_COUNT': 3, u'MAX_PHOTOS_PER_GALLERY': None})
 
     def test_get_plan_quota(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         p = u.userplan.plan
         self.assertEqual(p.get_quota_dict(),
                          {u'CUSTOM_WATERMARK': 1, u'MAX_GALLERIES_COUNT': 3, u'MAX_PHOTOS_PER_GALLERY': None})
 
 
     def test_extend_account_same_plan_future(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         u.userplan.expire = date.today() + timedelta(days=50)
         u.userplan.active = False
         u.userplan.save()
@@ -55,7 +55,7 @@ class PlansTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     def test_extend_account_same_plan_before(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         u.userplan.expire = date.today() - timedelta(days=50)
         u.userplan.active = False
         u.userplan.save()
@@ -73,7 +73,7 @@ class PlansTestCase(TestCase):
         Tests if mail has been send
         Tests if account has been activated
         """
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         u.userplan.expire = date.today() - timedelta(days=50)
         u.userplan.active = False
         u.userplan.save()
@@ -85,7 +85,7 @@ class PlansTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     def test_expire_account(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         u.userplan.expire = date.today() + timedelta(days=50)
         u.userplan.active = True
         u.userplan.save()
@@ -94,7 +94,7 @@ class PlansTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     def test_remind_expire(self):
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         u.userplan.expire = date.today() + timedelta(days=14)
         u.userplan.active = True
         u.userplan.save()
@@ -105,7 +105,7 @@ class PlansTestCase(TestCase):
     def test_disable_emails(self):
         with self.settings(SEND_PLANS_EMAILS=False):
             # Re-run the remind_expire test, but look for 0 emails sent
-            u = User.objects.get(username='test1')
+            u = get_user_model().objects.get(username='test1')
             u.userplan.expire = date.today() + timedelta(days=14)
             u.userplan.active = True
             u.userplan.save()
@@ -171,7 +171,7 @@ class TestInvoice(TestCase):
 
     def set_buyer_invoice_data(self):
         i = Invoice()
-        u = User.objects.get(username='test1')
+        u = get_user_model().objects.get(username='test1')
         i.set_buyer_invoice_data(u.billinginfo)
         self.assertEqual(i.buyer_name, u.billinginfo.name)
         self.assertEqual(i.buyer_street, u.billinginfo.street)
@@ -207,7 +207,7 @@ class TestInvoice(TestCase):
                                          "{% endifequal %}/{{ invoice.issued|date:'d/m/Y' }}"
         settings.INVOICE_COUNTER_RESET = Invoice.NUMBERING.DAILY
 
-        user = User.objects.get(username='test1')
+        user = get_user_model().objects.get(username='test1')
         plan_pricing = PlanPricing.objects.all()[0]
         tax = getattr(settings, "TAX")
         currency = getattr(settings, "CURRENCY")
@@ -259,7 +259,7 @@ class TestInvoice(TestCase):
                                          "{% endifequal %}/{{ invoice.issued|date:'m/Y' }}"
         settings.INVOICE_COUNTER_RESET = Invoice.NUMBERING.MONTHLY
 
-        user = User.objects.get(username='test1')
+        user = get_user_model().objects.get(username='test1')
         plan_pricing = PlanPricing.objects.all()[0]
         tax = getattr(settings, "TAX")
         currency = getattr(settings, "CURRENCY")
@@ -312,7 +312,7 @@ class TestInvoice(TestCase):
                                          "{% endifequal %}/{{ invoice.issued|date:'Y' }}"
         settings.INVOICE_COUNTER_RESET = Invoice.NUMBERING.ANNUALLY
 
-        user = User.objects.get(username='test1')
+        user = get_user_model().objects.get(username='test1')
         plan_pricing = PlanPricing.objects.all()[0]
         tax = getattr(settings, "TAX")
         currency = getattr(settings, "CURRENCY")
@@ -485,7 +485,7 @@ class ValidatorsTestCase(TestCase):
 
         class TestValidator(ModelCountValidator):
             code = 'QUOTA_NAME'
-            model = User
+            model = get_user_model()
 
         validator_object = TestValidator()
         self.assertRaises(ValidationError, validator_object, user=None, quota_dict={'QUOTA_NAME': 1})

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as file:
 
 setup(
     name='django-plans',
-    version='0.8',
+    version='0.8.1',
     description='Pluggable django app for managing pricing plans with quotas and accounts expiration',
     long_description=long_description,
     author='Krzysztof Dorosz',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as file:
 
 setup(
     name='django-plans',
-    version='0.7alpha',
+    version='0.8',
     description='Pluggable django app for managing pricing plans with quotas and accounts expiration',
     long_description=long_description,
     author='Krzysztof Dorosz',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as file:
 
 setup(
     name='django-plans',
-    version='0.8.1',
+    version='0.8.2',
     description='Pluggable django app for managing pricing plans with quotas and accounts expiration',
     long_description=long_description,
     author='Krzysztof Dorosz',


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/topics/auth/customizing/#substituting-a-custom-user-model is not supported by django-plans, since it has hard-coded references to 'auth.User'.

By default this patch doesn't do anything, since settings.AUTH_USER_MODEL defaults to auth.User, but when the developer changes the setting, it will allow him to keep using django-plans.

Without this patch, trying to run the unittests for a project that uses both settings.AUTH_USER_MODEL and django-plans returns:

```
Creating test database for alias 'default'...
CommandError: One or more models did not validate:
plans.plan: 'customized' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
plans.billinginfo: 'user' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
plans.userplan: 'user' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
plans.order: 'user' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
plans.invoice: 'user' defines a relation with the model 'auth.User', which has been swapped out. Update the relation to point at settings.AUTH_USER_MODEL.
```

https://github.com/cypreess/django-plans/issues/40
