### PR TITLE
New VAT standard rates 2017

### DIFF
--- a/plans/taxation/eu.py
+++ b/plans/taxation/eu.py
@@ -24,7 +24,7 @@ class EUTaxationPolicy(TaxationPolicy):
     """
 
     # Standard VAT rates according to http://ec.europa.eu/taxation_customs/resources/documents/taxation/vat/how_vat_works/rates/vat_rates_en.pdf
-    # Situation at 1 Jan 2015
+    # Situation at 1 Jan 2017
 
     EU_COUNTRIES_VAT = {
         'BE': Decimal('21'),  # Belgium


### PR DESCRIPTION
As of 1st of January 2017, two VAT rates have changed : Luxembourg (from 15 to 17%) and Romania (from 20% to 19% - Romania changed from 24% to 20% in 2016), Greece from 23% to 24% (changed in 2016)