### PR TITLE
Remove dependency on django.contrib.sites

### DIFF
--- a/plans/contrib.py
+++ b/plans/contrib.py
@@ -21,12 +21,15 @@ def send_template_email(recipients, title_template, body_template, context, lang
     domain = getattr(settings, 'SITE_URL', None)
 
     if domain is None:
-        Site = apps.get_model('sites', 'Site')
-        current_site = Site.objects.get_current()
-        site_name = current_site.name
-        domain = current_site.domain
+        try:
+            Site = apps.get_model('sites', 'Site')
+            current_site = Site.objects.get_current()
+            site_name = current_site.name
+            domain = current_site.domain
+        except LookupError:
+            pass
 
-    context.update({'site_name' : site_name, 'site_domain': domain})
+    context.update({'site_name': site_name, 'site_domain': domain})
 
     if language is not None:
         translation.activate(language)

--- a/plans/models.py
+++ b/plans/models.py
@@ -11,7 +11,10 @@ from django.db import models
 from django.db.models import Max
 
 from django.conf import settings
-from django.contrib.sites.models import Site
+try:
+    from django.contrib.sites.models import Site
+except RuntimeError:
+    Site = None
 from django.core.urlresolvers import reverse
 
 from django.template import Context
@@ -698,8 +701,11 @@ class Invoice(models.Model):
         self.tax_total = order.total() - order.amount
         self.tax = order.tax
         self.currency = order.currency
-        self.item_description = "%s - %s" % (
-            Site.objects.get_current().name, order.name)
+        if Site is not None:
+            self.item_description = "%s - %s" % (
+                Site.objects.get_current().name, order.name)
+        else:
+            self.item_description = order.name
 
     @classmethod
     def create(cls, order, invoice_type):


### PR DESCRIPTION
# What was wrong

`django-plans` assumes that `django.contrib.sites` is installed. The documentation at https://django-plans.readthedocs.io/en/latest/integration.html doesn't mention anything about having it in `INSTALLED_APPS`

# What this changes

When the `Site` model can't be imported, the item description will not contain the current site's name.

# How this fixes it.

Since `django.contrib.sites` is only used for populating the item description with the site name, falling back to not have the site name in the description mkaes `django.contrib.sites` an optional requirement.


Alternatively, we could fix the issue just on the documentation side by adding `'django.contrib.sites'` to https://github.com/cypreess/django-plans/blob/master/docs/source/integration.rst