### PR TITLE
Migrated to Django 2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 env:
-  - DJANGO_VERSION=1.10.8
-  - DJANGO_VERSION=1.11.8
+  - DJANGO_VERSION=2.0.2
 # command to install dependencies
 install:
   - "pip install -q -e ."

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,8 @@ django-plans changelog
 
 0.8 (UNRELEASED)
 -----------------
-* Supporting Django 1.10.8, 1.11.8.
-* Tests for latest versions of Python (3.5, 3.6).
+* Supporting Django 2.0.2.
+* Tests for latest versions of Python (3.6).
 * New VAT standard rates 2017
 * Remove dependency on `django.contrib.sites`.
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features currently supported:
 
 Documentation: https://django-plans.readthedocs.org/
 
-Master branch: experimental support for django 1.6, experimental support for py2.7 & py3.3
+Master branch: Support for django 2.0, support for py3.6
 
 .. image:: docs/source/_static/images/django-plans-1.png
 

--- a/demo/example/foo/models.py
+++ b/demo/example/foo/models.py
@@ -7,7 +7,7 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class Foo(models.Model):
-    user = models.ForeignKey('auth.User')
+    user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     name = models.CharField(max_length=100, default="A new foo")
 
     def __str__(self):

--- a/demo/example/foo/urls.py
+++ b/demo/example/foo/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import path
 
 from django.contrib.auth.decorators import login_required
 
-from example.foo.views import FooListView, FooCreateView, FooDeleteView
+from .views import FooListView, FooCreateView, FooDeleteView
 
 
 urlpatterns = [
-    url(r'^list/$', login_required(FooListView.as_view()), name='foo_list'),
-    url(r'^add/$', login_required(FooCreateView.as_view()), name='foo_add'),
-    url(r'^del/(?P<pk>\d+)/$', login_required(FooDeleteView.as_view()), name='foo_del'),
+    path('list/', login_required(FooListView.as_view()), name='foo_list'),
+    path('add/', login_required(FooCreateView.as_view()), name='foo_add'),
+    path('del/<int:pk>/', login_required(FooDeleteView.as_view()), name='foo_del'),
 ]

--- a/demo/example/foo/views.py
+++ b/demo/example/foo/views.py
@@ -1,6 +1,6 @@
 # Create your views here.
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from django.views.generic import ListView, CreateView, DeleteView
 from .forms import FooForm

--- a/demo/example/urls.py
+++ b/demo/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib import admin
 from django.views.generic.base import TemplateView
 
@@ -7,10 +7,10 @@ from django.contrib.auth import views
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='home.html'), name='home'),
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^plan/', include('plans.urls')),
-    url(r'^accounts/login/$', views.login, name="login"),
-    url(r'^accounts/logout/$', views.logout, {'next_page': '/'}, name="logout"),
-    url(r'^foo/', include('example.foo.urls')),
+    path('', TemplateView.as_view(template_name='home.html'), name='home'),
+    path('admin/', admin.site.urls),
+    path('plan/', include('plans.urls')),
+    path('accounts/login/', views.login, name="login"),
+    path('accounts/logout/', views.logout, {'next_page': '/'}, name="logout"),
+    path('foo/', include('example.foo.urls')),
 ]

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,4 @@
-django==1.11.7
+django==2.0.2
 django-bootstrap3
 Sphinx
 django-debug-toolbar

--- a/plans/admin.py
+++ b/plans/admin.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 from django.contrib import admin
-from django.core import urlresolvers
+from django.urls import reverse
 from ordered_model.admin import OrderedModelAdmin
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,7 +11,7 @@ from plans.models import Invoice
 
 class UserLinkMixin(object):
     def user_link(self, obj):
-        change_url = urlresolvers.reverse('admin:auth_user_change', args=(obj.user.id,))
+        change_url = reverse('admin:auth_user_change', args=(obj.user.id,))
         return '<a href="%s">%s</a>' % (change_url, obj.user.username)
 
     user_link.short_description = 'User'

--- a/plans/context_processors.py
+++ b/plans/context_processors.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from plans.models import UserPlan
 
@@ -16,7 +16,7 @@ def account_status(request):
 
     """
 
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         try:
             return {
                 'ACCOUNT_EXPIRED': request.user.userplan.is_expired(),

--- a/plans/views.py
+++ b/plans/views.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView, RedirectView, CreateView, UpdateView, View
@@ -91,7 +91,7 @@ class PlanTableViewBase(PlanTableMixin, ListView):
     def get_queryset(self):
         queryset = super(PlanTableViewBase, self).get_queryset().prefetch_related('planpricing_set__pricing',
                                                                                   'planquota_set__quota')
-        if self.request.user.is_authenticated():
+        if self.request.user.is_authenticated:
             queryset = queryset.filter(
                 Q(available=True, visible=True) & (
                     Q(customized=self.request.user) | Q(customized__isnull=True)
@@ -104,7 +104,7 @@ class PlanTableViewBase(PlanTableMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super(PlanTableViewBase, self).get_context_data(**kwargs)
 
-        if self.request.user.is_authenticated():
+        if self.request.user.is_authenticated:
             try:
                 self.userplan = UserPlan.objects.select_related('plan').get(user=self.request.user)
             except UserPlan.DoesNotExist:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 python_files=test*.py
 addopts=--tb=short
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
         'django-countries>=4.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py36
 
 [testenv]
 deps=-r{toxinidir}/demo/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py27,py36
 
 [testenv]
 deps=-r{toxinidir}/demo/requirements.txt


### PR DESCRIPTION
- Explicitly set `on_delete` to `CASCADE` for all models. [The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations. Consider squashing migrations so that you have fewer of them to update.
](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)
- Updated urlpatterns to use `path` instead of `url`. [Simplified URL routing syntax](https://docs.djangoproject.com/en/2.0/releases/2.0/#simplified-url-routing-syntax)
- Updated `reverse` module path.
- Removed call to `User.is_authenticated`. [Using User.is_authenticated() and User.is_anonymous() as methods rather than properties is no longer supported.
](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)
- Changed Django and Python version in requirements.txt and CI config files.
- Updated docs a bit.