### PR TITLE
tasks: support customised user model

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ django-plans changelog
 * Remove dependency on `django.contrib.sites`.
 * Feature #53: Cleaner and more explicit exception handling on `Plan.get_default_plan `.
 * Feature #59: Adding code coverage to code base.
+* Support customised user models by using `django.contrib.auth.get_user_model()`.
+
 
 0.7
 ---

--- a/plans/listeners.py
+++ b/plans/listeners.py
@@ -1,8 +1,12 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from plans.models import Order, Invoice, UserPlan, Plan
 from plans.signals import order_completed, activate_user_plan
+
+
+User = get_user_model()
+
 
 @receiver(post_save, sender=Order)
 def create_proforma_invoice(sender, instance, created, **kwargs):

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -3,8 +3,10 @@ import logging
 from celery.schedules import crontab
 from celery.task.base import periodic_task
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
+
+User = get_user_model()
 logger = logging.getLogger('plans.tasks')
 
 @periodic_task(run_every=crontab(hour=0, minute=5))

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.core import mail
 from django.db.models import Q
@@ -21,6 +21,9 @@ from plans.plan_change import PlanChangePolicy, StandardPlanChangePolicy
 from plans.taxation.eu import EUTaxationPolicy
 from plans.quota import get_user_quota
 from plans.validators import ModelCountValidator
+
+
+User = get_user_model()
 
 
 class PlansTestCase(TestCase):


### PR DESCRIPTION
Go through django.contrib.auth.get_user_model() instead of a direct model import.